### PR TITLE
Allow lowercase bearer

### DIFF
--- a/lib/authorise.js
+++ b/lib/authorise.js
@@ -72,7 +72,7 @@ function getBearerToken (done) {
 
   // Header: http://tools.ietf.org/html/rfc6750#section-2.1
   if (headerToken) {
-    var matches = headerToken.match(/Bearer\s(\S+)/);
+    var matches = headerToken.match(/[bB]earer\s(\S+)/);
 
     if (!matches) {
       return done(error('invalid_request', 'Malformed auth header'));


### PR DESCRIPTION
Trent, can you please merge this into your branch?  Our iOS app uses "bearer" instead of "Bearer".  (I'm correcting that but for backward compatibility we'll need this change.)